### PR TITLE
Child modules grey listing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/*
 composer.lock
 .idea
 tests/src/data/config/*
+build/*

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,4 +18,17 @@
       <directory>tests</directory>
     </testsuite>
   </testsuites>
+
+  <filter>
+    <whitelist>
+      <directory suffix=".php">./src/</directory>
+    </whitelist>
+  </filter>
+
+  <logging>
+    <log type="junit" target="build/tests/report.junit.xml"/>
+    <log type="coverage-html" target="build/tests/coverage" lowUpperBound="35" highLowerBound="70"/>
+    <log type="coverage-text" target="build/tests/coverage.txt"/>
+    <log type="coverage-clover" target="build/tests/logs/clover.xml"/>
+  </logging>
 </phpunit>

--- a/src/Command/ConfigSplitMerge.php
+++ b/src/Command/ConfigSplitMerge.php
@@ -408,11 +408,16 @@ class ConfigSplitMerge extends Command
     }
     $output[] = '  ];';
     $output[] = '';
+    $output[] = '  $configFactory = \Drupal::service(\'config.factory\');';
+    $output[] = '';
     $output[] = '  foreach ($fieldChanges as $field => $uuid) {';
-    $output[] = '    $config = \Drupal::service(\'config.factory\')->getEditable($field);';
-    $output[] = '    $config->set(\'uuid\', $uuid)->save();';
+    $output[] = '    if ($configFactory->loadMultiple([$field])) {';
+    $output[] = '      $config = $configFactory->getEditable($field);';
+    $output[] = '      $config->set(\'uuid\', $uuid)->save();';
+    $output[] = '    }';
     $output[] = '  }';
     $output[] = '}';
+    $output[] = '';
 
     return $output;
   }

--- a/tests/src/ConfigSplitMergeTest.php
+++ b/tests/src/ConfigSplitMergeTest.php
@@ -108,12 +108,15 @@ class ConfigSplitMergeTest extends TestCase
     $this->assertFileExists(__DIR__ . '/data/config/default/config_split.config_split.parent.yml');
     $this->assertFileExists(__DIR__ . '/data/config/default/config_split.config_split.child1.yml');
     $this->assertFileExists(__DIR__ . '/data/config/default/node.type.landing_page.yml');
+    $this->assertFileExists(__DIR__ . '/data/config/default/core.extension.yml');
 
     $this->assertFileNotExists(__DIR__ . '/data/config/parent/node.type.landing_page.yml');
     $this->assertFileExists(__DIR__ . '/data/config/parent/node.type.page.yml');
     $this->assertFileExists(__DIR__ . '/data/config/parent/system.site.yml');
+    $this->assertFileNotExists(__DIR__ . '/data/config/child1/core.extension.yml');
 
     $this->assertFileNotExists(__DIR__ . '/data/config/child1/node.type.landing_page.yml');
+    $this->assertFileNotExists(__DIR__ . '/data/config/child1/core.extension.yml');
     $this->assertFileExists(__DIR__ . '/data/config/child1/system.site.yml');
 
     $this->assertContains("'node.type.landing_page' => '2034e796-4d2c-43f0-9135-1afc93052380',", $output, '');
@@ -157,13 +160,20 @@ class ConfigSplitMergeTest extends TestCase
     $this->assertFileExists(__DIR__ . '/data/config/default/config_split.config_split.parent.yml');
     $this->assertFileExists(__DIR__ . '/data/config/default/config_split.config_split.child1.yml');
     $this->assertFileExists(__DIR__ . '/data/config/default/node.type.landing_page.yml');
+    $this->assertFileExists(__DIR__ . '/data/config/default/core.extension.yml');
 
     $this->assertFileNotExists(__DIR__ . '/data/config/parent/node.type.landing_page.yml');
     $this->assertFileExists(__DIR__ . '/data/config/parent/node.type.page.yml');
     $this->assertFileExists(__DIR__ . '/data/config/parent/system.site.yml');
+    $this->assertFileNotExists(__DIR__ . '/data/config/parent/core.extension.yml');
 
     $this->assertFileNotExists(__DIR__ . '/data/config/child1/node.type.landing_page.yml');
     $this->assertFileExists(__DIR__ . '/data/config/child1/system.site.yml');
+    $this->assertFileNotExists(__DIR__ . '/data/config/child1/core.extension.yml');
+
+    $this->assertFileNotExists(__DIR__ . '/data/config/child2/node.type.landing_page.yml');
+    $this->assertFileExists(__DIR__ . '/data/config/child2/system.site.yml');
+    $this->assertFileNotExists(__DIR__ . '/data/config/child2/core.extension.yml');
 
     $this->assertContains("'node.type.landing_page' => '2034e796-4d2c-43f0-9135-1afc93052380',", $output, '');
 
@@ -176,8 +186,9 @@ class ConfigSplitMergeTest extends TestCase
     $configSplitFileContents = file_get_contents($configSplitFile);
     $configSplit = Yaml::decode($configSplitFileContents);
     $this->assertFalse(isset($configSplit['blacklist'][0]));
+    $this->assertTrue(isset($configSplit['module']['my_custom_payment_module']));
+    $this->assertEquals($configSplit['module']['my_custom_payment_module'], 0);
   }
-
 
   /**
    * Set up the configuration test by copying one of the test configuration

--- a/tests/src/data/configtest/child1/core.extension.yml
+++ b/tests/src/data/configtest/child1/core.extension.yml
@@ -1,0 +1,21 @@
+module:
+  admin_toolbar: 0
+  entity: 0
+  field: 0
+  field_ui: 0
+  node: 0
+  my_custom_payment_module: 0
+  system: 0
+  text: 0
+  toolbar: 0
+  random_module_number1: 0
+  user: 0
+  views: 10
+  views_ui: 0
+theme:
+  stable: 0
+  classy: 0
+  seven: 0
+profile: standard
+_core:
+  default_config_hash: bla

--- a/tests/src/data/configtest/child1/node.type.article.yml
+++ b/tests/src/data/configtest/child1/node.type.article.yml
@@ -1,0 +1,21 @@
+uuid: 2018b5ae-8b5d-46a3-8385-6b826237dbfe
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus:
+      - footer
+      - main
+    parent: 'main:'
+_core:
+  default_config_hash: bla
+name: 'Article'
+type: article
+description: 'Article content type'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: false

--- a/tests/src/data/configtest/child2/core.extension.yml
+++ b/tests/src/data/configtest/child2/core.extension.yml
@@ -1,0 +1,19 @@
+module:
+  admin_toolbar: 0
+  entity: 0
+  field: 0
+  field_ui: 0
+  node: 0
+  system: 0
+  text: 0
+  toolbar: 0
+  user: 0
+  views: 10
+  views_ui: 0
+theme:
+  stable: 0
+  classy: 0
+  seven: 0
+profile: standard
+_core:
+  default_config_hash: bla

--- a/tests/src/data/configtest/parent/core.extension.yml
+++ b/tests/src/data/configtest/parent/core.extension.yml
@@ -1,0 +1,19 @@
+module:
+  admin_toolbar: 0
+  entity: 0
+  field: 0
+  field_ui: 0
+  node: 0
+  system: 0
+  text: 0
+  toolbar: 0
+  user: 0
+  views: 10
+  views_ui: 0
+theme:
+  stable: 0
+  classy: 0
+  seven: 0
+profile: standard
+_core:
+  default_config_hash: bla

--- a/tests/src/data/configtest/parent/node.type.article.yml
+++ b/tests/src/data/configtest/parent/node.type.article.yml
@@ -1,0 +1,21 @@
+uuid: 2018b5ae-8b5d-46a3-8385-6b826237dbfe
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus:
+      - footer
+      - main
+    parent: 'main:'
+_core:
+  default_config_hash: bla
+name: 'Article'
+type: article
+description: 'Article content type'
+help: ''
+new_revision: false
+preview_mode: 0
+display_submitted: true


### PR DESCRIPTION
# Changes
- Sorted out the way in which child modules are split out from the default config so that they are included in the config split files for just those children.
- Refactored the yaml file extraction code.
- Couple of bug fixes or general oversights.
- Improved the test coverage of the project and added coverage reports to the phpunit.xml file.